### PR TITLE
Set `post-self-insert-hook` locally in minor mode

### DIFF
--- a/electric-spacing.el
+++ b/electric-spacing.el
@@ -69,14 +69,12 @@
     (?. . electric-spacing-.)))
 
 (defun electric-spacing-post-self-insert-function ()
-  (when electric-spacing-mode
-    (let ((rule (cdr (assq last-command-event electric-spacing-rules))))
-      (when rule
-        (goto-char (electric--after-char-pos))
-        (delete-char -1)
-        (funcall rule)))))
+  (let ((rule (cdr (assq last-command-event electric-spacing-rules))))
+    (when rule
+      (goto-char (electric--after-char-pos))
+      (delete-char -1)
+      (funcall rule))))
 
-(add-hook 'post-self-insert-hook #'electric-spacing-post-self-insert-function)
 
 ;;;###autoload
 (define-minor-mode electric-spacing-mode
@@ -90,7 +88,14 @@ inserts surrounding spaces.  e.g., `=' becomes ` = ',`+=' becomes ` += '.  This
 is very handy for many programming languages."
   :global nil
   :group 'electricity
-  :lighter " _+_")
+  :lighter " _+_"
+
+  ;; body
+  (if electric-spacing-mode
+      (add-hook 'post-self-insert-hook
+                #'electric-spacing-post-self-insert-function nil t)
+    (remove-hook 'post-self-insert-hook
+                 #'electric-spacing-post-self-insert-function t)))
 
 (defun electric-spacing-self-insert-command ()
   "Insert character with surrounding spaces."


### PR DESCRIPTION
Rather than adding `electric-spacing-post-self-insert-function` to
`post-self-insert-hook` globally when `electric-spacing.el` is loaded we
add it to the buffer-local hook when the minor mode is enabled.

This has the (fairly minor) advantage of not calling
`electric-spacing-post-self-insert-function` unless the minor mode is
enabled (whereas before the function was always called but did nothing
if the minor mode was not enabled).

It also means that merely loading the library doesn't modify any hooks.
I think this is a little bit "nicer".
