### PR TITLE
Python colon operator

### DIFF
--- a/electric-spacing.el
+++ b/electric-spacing.el
@@ -195,7 +195,7 @@ so let's not get too insert-happy."
            (electric-spacing-insert ":" 'middle)))
         ((derived-mode-p 'haskell-mode)
          (electric-spacing-insert ":"))
-        ((derived-mode-p  'python-mode 'ess-mode)
+        ((derived-mode-p 'python-mode 'ess-mode)
          (insert ":"))
         (t
          (electric-spacing-insert ":" 'after))))

--- a/electric-spacing.el
+++ b/electric-spacing.el
@@ -195,6 +195,8 @@ so let's not get too insert-happy."
            (electric-spacing-insert ":" 'middle)))
         ((derived-mode-p 'haskell-mode)
          (electric-spacing-insert ":"))
+        ((derived-mode-p  'python-mode 'ess-mode)
+         (insert ":"))
         (t
          (electric-spacing-insert ":" 'after))))
 


### PR DESCRIPTION
Sorry for the bombardment of pull requests! I've been fixing things as they come up and I figured I should send the changes before there are too many of them to merge easily.

This change might come with a bit of a problem: the conditions on lines 196 (not my addition) and 198 will change the spacing around ':' for comments/strings in haskell/python/R modes. I think there are other similar cases throughout the code. It might be worth explicitly handling the case where we are in strings/comments/text-mode somewhere separate to avoid this happening.
