### PR TITLE
Fix unbalanced parenthesis error on compilation.

### DIFF
--- a/electric-spacing.el
+++ b/electric-spacing.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2004, 2005, 2007-2015 Free Software Foundation, Inc.
 
 ;; Author: William Xu <william.xwl@gmail.com>
-;; Version: 5.0
+;; Version: 5.0.1
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -83,7 +83,7 @@ to enable only in control statements."
     (?, . electric-spacing-\,)
     (?~ . electric-spacing-~)
     (?. . electric-spacing-.)
-    (?( . electric-spacing-left-paren)
+    (?\( . electric-spacing-left-paren)
     (?^ . electric-spacing-self-insert-command)))
 
 (defun electric-spacing-post-self-insert-function ()


### PR DESCRIPTION
The pattern `?(` is invalid, the `(` paren must be escaped.  This patch fixes the error.